### PR TITLE
fix: React APP Render - `npm run dev`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
       OpenAPI.TOKEN = import.meta.env.VITE_TOKEN;
     }
     whoami();
-    executeTest();
+    executeTest().then();
   }, []);
 
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,3 +13,9 @@ globalThis.render = () =>
       <App />
     </React.StrictMode>
   );
+
+if (import.meta.env.MODE === "development") {
+  console.log("Running in development mode");
+  console.log("Start Render App");
+  globalThis.render()
+}


### PR DESCRIPTION
If the user starts with `npm run dev`, the React App is not rendered.
We must invoke the render function when `import.meta.env.MODE === "development"`.